### PR TITLE
Update ObjectSocket.js

### DIFF
--- a/nodejs/ObjectSocket.js
+++ b/nodejs/ObjectSocket.js
@@ -13,7 +13,7 @@ var ObjectSocket = (function (_super) {
         this._bufferOffset = 0;
         this._lastLen = 0;
         this._buffer = new Buffer(1024);
-        this._open = false;
+        this._open = true;
         this._socket = socket;
         var This = this;
         this._socket.on("connect", function () {


### PR DESCRIPTION
当socket连接本地的时候,connect事件注册之前就已经连接成功,因此不会触发connect事件.该类就报废了..我在stackoverflow上面看到很多这样的问题..因此进行了修改.
